### PR TITLE
Add more waits when fetching mentor request queues

### DIFF
--- a/cogs/mentor_requests.py
+++ b/cogs/mentor_requests.py
@@ -71,7 +71,7 @@ class RequestNotifier(commands.Cog):
                     "message_id": message.id,
                 }
                 self.conn.execute(QUERY["add_request"], data)
-            await asyncio.sleep(1)
+            await asyncio.sleep(2)
 
         for request_id, (track, message) in list(self.requests.items()):
             if request_id in current_request_ids:


### PR DESCRIPTION
The bot is getting throttled (429) on fetching mentor requests. Adding more waits to reduce 429's.