### PR TITLE
Fixing regex for track names ending with non alphanum character

### DIFF
--- a/cogs/track_react.py
+++ b/cogs/track_react.py
@@ -67,12 +67,13 @@ class TrackReact(commands.Cog):
             word_boundary_end = r"\b"
             assert len(track) > 0
             if not track[-1].isalnum():
-                # the word boundary will match word beginning or ending
-                # however if the track name's last character is not a
-                # word character the boundary will match to the next
-                # word starting like "c++lang" and not "c++ lang"
-                # "\B" will reverse this, and only match if next character
-                # does not start a word
+                # The word boundary, `\b` will match word beginning or ending.
+                # However, if the track name's last character is not a word
+                # character (e.g. `C++`), the boundary will match to the next
+                # word starting.
+                # For example, `\bc\+\+\b` will match "c++lang" and not "c++ lang".
+                # `\B` will reverse this, and only matches if next character
+                # does not start a word.
                 word_boundary_end = r"\B"
             compiled = re.compile(r"\b" + track + word_boundary_end, flags)
             re_reacts[compiled] = emoji

--- a/cogs/track_react.py
+++ b/cogs/track_react.py
@@ -64,7 +64,7 @@ class TrackReact(commands.Cog):
             # Mutli-word tracks: convert _ to .?
             track = track.replace("_", ".?")
 
-            compiled = re.compile(r"\b" + track + r"\b", flags)
+            compiled = re.compile(r"\b" + track + (r"\b" if track[-1].isalnum() else r"\B"), flags)
             re_reacts[compiled] = emoji
         self.reacts = re_reacts
 

--- a/cogs/track_react.py
+++ b/cogs/track_react.py
@@ -64,7 +64,17 @@ class TrackReact(commands.Cog):
             # Mutli-word tracks: convert _ to .?
             track = track.replace("_", ".?")
 
-            compiled = re.compile(r"\b" + track + (r"\b" if track[-1].isalnum() else r"\B"), flags)
+            word_boundary_end = r"\b"
+            assert len(track) > 0
+            if not track[-1].isalnum():
+                # the word boundary will match word beginning or ending
+                # however if the track name's last character is not a
+                # word character the boundary will match to the next
+                # word starting like "c++lang" and not "c++ lang"
+                # "\B" will reverse this, and only match if next character
+                # does not start a word
+                word_boundary_end = r"\B"
+            compiled = re.compile(r"\b" + track + word_boundary_end, flags)
             re_reacts[compiled] = emoji
         self.reacts = re_reacts
 


### PR DESCRIPTION
The regex r"\bc\\+\\+\b" does not match to "Hi c++ track!" because the last '+' character is not on word boundary!
"Hi c++track" does match, which is not desired.

The word boundary matcher is made conditional on the track name (or alias) last character being alphanumeric.