### PR TITLE
Stop bot replying to it's own inclusivity message

### DIFF
--- a/cogs/inclusive_language.py
+++ b/cogs/inclusive_language.py
@@ -53,6 +53,8 @@ class InclusiveLanguage(commands.Cog):
     async def on_message(self, message: discord.Message) -> None:
         """Add Emoji reactions on a new message."""
         channel = message.channel
+        if message.author.bot:
+            return
         if channel is None:
             return
         if not any(pattern.search(message.content) for pattern in self.patterns):


### PR DESCRIPTION
This morning the discord bot got stuck in an infinite loop telling itself to be inclusive because it was saying the things it was checking against. I have added a simple check to avoid the bot telling itself (or any other bot) off!

I haven't tested this since it is a lot of work to create a bot and put it into my server to test it, but given it's simplicity I doubt that should be a problem.