### PR TITLE
[Fix] beginner message

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -44,16 +44,16 @@ CANNED_MESSAGES = {
         "being-a-good-community-member/suggesting-exercise-improvements before posting."
     ),
     "beginner": (
-        "👋🏼  Hello! We are happy to have you here."
+        "👋🏼  Hello! We are happy to have you here. "
         "Exercism is best suited for people who have some experience in programming. "
         "If you are completely new to the topic, exercism might be very challenging. "
         "There are many great resources online, that can kickstart your journey in "
         "computer science. For a wide understanding, you can try the free CS50x course "
-        "at Harvard: cs50.harvard.edu/x/2023/. If you want to focus on web development "
-        "you can also try the Odin Projects (free and open source). It is a long-term "
-        "commitment, that will guide you to master some projects and will prepare you to "
-        "show off a nice portfolio in the end. theodinproject.com. Another interesting "
-        "resource are the MDN web docs: developer.mozilla.org/en-US/docs/Learn."
+        "at Harvard: http://cs50.harvard.edu/x/2023/. If you want to focus on web development "
+        "you can also try The Odin Projects (free and open source: http:// theodinproject.com). "
+        "It is a long-term commitment, that will guide you to master some projects and will prepare you to "
+        "show off a nice portfolio in the end. Another interesting "
+        "resource for web development are the MDN web docs: http://developer.mozilla.org/en-US/docs/Learn."
     ),
 }
 


### PR DESCRIPTION
- without `http://` the links were not converted to hyperlinks
- The Odin Project uses a capital T
- Fixed missing spaces at the end of the line