### PR TITLE
Inclusive Language: Reset the thread auto archive to 1 hour, independent of temporal bot messages

### DIFF
--- a/cogs/inclusive_language.py
+++ b/cogs/inclusive_language.py
@@ -59,7 +59,7 @@ class InclusiveLanguage(base_cog.BaseCog):
         elif channel.type == discord.ChannelType.text:
             typed_channel = cast(discord.TextChannel, channel)
             thread = await typed_channel.create_thread(
-                name=TITLE, auto_archive_duration=DURATION
+                name=TITLE, auto_archive_duration=60
             )
             content = f"{message.author.mention} {MESSAGE}\n\n{message.jump_url}"
             await thread.send(content=content, suppress_embeds=True)


### PR DESCRIPTION
Auto archive duration must be selected from fixed duration and is in minutes, not seconds.